### PR TITLE
Adapt producer to kernel registration pipeline

### DIFF
--- a/internal/kernel/kernel.go
+++ b/internal/kernel/kernel.go
@@ -150,7 +150,7 @@ func (k *Kernel) consumeRedis(ctx context.Context) {
                 }
                 // Authenticate producer if required
                 if k.au != nil && k.cfg.Auth.RequireToken {
-                    if _, _, err := k.au.Verify(ctx, token); err != nil {
+                    if _, _, _, err := k.au.Verify(ctx, token); err != nil {
                         metrics.AuthDeniedTotal.Inc()
                         _ = k.rd.ToDLQ(ctx, dlq, id, payload, "unauthenticated")
                         logging.Warn("redis_auth_denied", logging.F("id", id), logging.Err(err))

--- a/modules.d/producer-example/config.example.yaml
+++ b/modules.d/producer-example/config.example.yaml
@@ -13,10 +13,10 @@ producer:
   name: "demo-producer"
   contact: "demo@example.com"
   send_interval_ms: 1000
-  # Registration signing keys (producer identity)
+  # Registration identity (certificate-only, signed by Producer CA)
+  # Certificate is REQUIRED. No fallback to raw SSH public key.
   ssh_private_key_file: "./modules.d/producer-example/ssh/id_ed25519"
   ssh_public_key_file: "./modules.d/producer-example/ssh/id_ed25519.pub"
-  # If you use producer SSH certificates, set the certificate file too (signed by producer CA)
   ssh_cert_file: "./modules.d/producer-example/ssh/id_ed25519-cert.pub"
   # Schema provisioning
   schema_name: "demo_schema"


### PR DESCRIPTION
Automate producer registration and token refresh, enforcing certificate-only identity, and fixing a kernel API call.

The producer example now uses cryptographically random nonces and automatically refreshes its authentication token before expiry, ensuring continuous and secure operation. It strictly adheres to certificate-based registration and its operational flow is now fully automated, reacting to registration responses before proceeding with subject provisioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7611f80-6c06-4758-9e36-b7b38b5d5118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7611f80-6c06-4758-9e36-b7b38b5d5118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

